### PR TITLE
adding maximum session timeout variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,7 @@ resource "aws_iam_role" "provisioner" {
   name = var.name
   description = var.description
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
+  max_session_duration = var.max_session_duration
 }
 
 # This policy grants the provisioner user access to specific paths in the S3 bucket holding terraform state.

--- a/variables.tf
+++ b/variables.tf
@@ -60,3 +60,8 @@ variable "trusted_account" {
   default = null
   type = string
 }
+
+variable "max_session_duration" {
+  default = "7200"
+  description = "The maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default maximum of two hour is applied. This setting can have a value from 1 hour to 12 hours."
+}


### PR DESCRIPTION
This change adds maximum_session_timeout variable and its set to default for 2 hours compared to previous 1hour set